### PR TITLE
Plan migration cleanup from Poetry to uv

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,38 +13,71 @@
 
 ## Installation
 
-Calcipy needs a few static files managed using copier and a template project: [kyleking/calcipy_template](https://github.com/KyleKing/calcipy_template/)
+`calcipy` can be used in two ways:
 
-You can quickly use the template to create a new project or add calcipy to an existing one:
+### 1. As a Standalone Tool (Recommended for Linting & Code Analysis)
+
+Use `calcipy` as a standalone tool without adding it as a dependency. This is ideal for:
+- **Linting**: Running `ruff` on any Python codebase
+- **Code Tag Collection**: Creating TODO/FIXME summaries for any project
 
 ```sh
-# Below examples assume you have Astral uv installed (which provides uvx)
-#   If you have your shell configured, `uv tool install copier` allows usage of `copier ...` instead of `uvx copier ...`
+# Install as a tool (minimal dependencies)
+uv tool install 'calcipy[tool]'
 
-# To create a new project
+# Or use without installing via uvx
+uvx --from 'calcipy[tool]' calcipy-lint --help
+uvx --from 'calcipy[tool]' calcipy-tags --help
+
+# Examples
+calcipy-lint lint --help
+calcipy-lint lint  # Lint current directory
+
+calcipy-tags tags --help
+calcipy-tags tags --base-dir=~/path/to/my_project
+```
+
+**Tool Mode Capabilities:**
+- ✅ `calcipy-lint` - Lint any Python codebase
+- ✅ `calcipy-tags` - Collect code tags from any directory
+- ⚠️  Other commands require project context (see below)
+
+### 2. As a Project Dependency (Full Development Environment)
+
+Add `calcipy` to your project for the complete development workflow including testing, documentation, type-checking, and more.
+
+#### Quick Start with Template
+
+Calcipy works best with its companion template project: [kyleking/calcipy_template](https://github.com/KyleKing/calcipy_template/)
+
+```sh
+# Create a new project from template
 uvx copier copy gh:KyleKing/calcipy_template new_project
 cd new_project
 
-# Or convert/update an existing one
+# Or add to existing project
 cd my_project
 uvx copier copy gh:KyleKing/calcipy_template .
 uvx copier update
 ```
 
-### Calcipy CLI
-
-Additionally, `calcipy` can be run as a CLI application without adding the package as a dependency.
-
-Quick Start:
+#### Manual Installation
 
 ```sh
-# For the CLI, only install a few of the extras which can be used from a few different CLI commands
-uv tool install 'calcipy[lint,tags]'
+# Add as development dependency with all tools
+uv add --dev 'calcipy[dev]'
 
-# Use 'tags' to create a CODE_TAG_SUMMARY of the specified directory
-calcipy-tags tags --help
-calcipy-tags tags --base-dir=~/path/to/my_project
+# Or install specific extras
+uv add --dev 'calcipy[test,doc,types]'
 ```
+
+**Project Mode Capabilities:**
+- ✅ All tool mode features
+- ✅ `calcipy-test` - Run pytest with coverage
+- ✅ `calcipy-types` - Type checking with mypy/pyright
+- ✅ `calcipy-docs` - Build and deploy documentation
+- ✅ `calcipy-pack` - Package building and publishing
+- ✅ `calcipy` - Full task automation
 
 Note: the CLI output below is compressed for readability, but you can try running each of these commands locally to see the most up-to-date documentation and the full set of options. The "Usage", "Core options", and "Global Task Options" are the same for each subsequent command, so they are excluded for brevity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,37 @@ requires-python = ">=3.9.13"
 version = "5.0.0"
 
 [project.optional-dependencies]
+# Standalone tool usage - minimal dependencies for CLI tools
+# Install with: uv tool install 'calcipy[tool]'
+tool = [
+  "arrow >=1.3.0",        # For tags task
+  "pyyaml >=6.0.2",       # For tags task
+  "ruff >=0.8.2",         # For lint task
+]
+
+# Full development environment - all dependencies for project development
+# Install with: uv add --dev 'calcipy[dev]'
+dev = [
+  "arrow >=1.3.0",
+  "commitizen >=3.29.1",
+  "griffe >=1.3.2",
+  "mkdocs >=1.6.1",
+  "mkdocs-gen-files >=0.5.0",
+  "mkdocs-material >=9.5.39",
+  "mkdocstrings[python] >=0.26.1",
+  "mypy >=1.11.2",
+  "nox >=2024.10.9",
+  "pymdown-extensions >=10.11.2",
+  "pytest >=8.3.3",
+  "pytest-cov >=5.0.0",
+  "pytest-randomly >=3.15.0",
+  "pytest-watcher >=0.4.3",
+  "pyyaml >=6.0.2",
+  "ruff >=0.8.2",
+  "semver >=3.0.2",
+]
+
+# Individual extras (maintained for backward compatibility)
 ddict = [
   "python-box >=7.2.0",
 ]

--- a/src/calcipy/experiments/sync_package_dependencies.py
+++ b/src/calcipy/experiments/sync_package_dependencies.py
@@ -4,6 +4,8 @@ Supports both poetry.lock and uv.lock formats.
 
 """
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
 
@@ -18,6 +20,118 @@ def _extract_base_version(version_spec: str) -> str:
     return version_match.group(1) if version_match else version_spec
 
 
+def _parse_pep621_dependency(dep_spec: str) -> tuple[str, str] | None:
+    """Parse a PEP 621 dependency string into (package_name, version).
+
+    Handles formats like:
+    - "package>=1.0.0"
+    - "package[extra]>=1.0.0"
+    - "package[extra1,extra2]>=1.0.0"
+
+    Args:
+        dep_spec: Dependency specification string
+
+    Returns:
+        Tuple of (package_name, version) or None if no version specified
+
+    """
+    # Match package name (with optional extras) and version spec
+    # Package name can contain letters, numbers, hyphens, underscores
+    # Extras are in square brackets
+    # Version spec starts with comparison operators
+    match = re.match(r'^([a-zA-Z0-9_-]+(?:\[[^\]]+\])?)([><=!~].+)?$', dep_spec.strip())
+    if not match:
+        return None
+
+    package_name = match.group(1)
+    version_spec = match.group(2)
+
+    # Remove extras from package name for version tracking
+    base_package_name = re.sub(r'\[.+\]', '', package_name)
+
+    if version_spec:
+        return (base_package_name, _extract_base_version(version_spec))
+
+    return None
+
+
+def _collect_uv_dependencies(pyproject: dict) -> dict[str, str]:
+    """Collect dependencies from UV format sections.
+
+    Args:
+        pyproject: Parsed pyproject.toml data
+
+    Returns:
+        Dictionary mapping package names to versions
+
+    """
+    versions: dict[str, str] = {}
+    deps_sources: list = []
+
+    # Collect from [project.dependencies]
+    if 'project' in pyproject:
+        if 'dependencies' in pyproject['project']:
+            deps_sources.append(pyproject['project']['dependencies'])
+
+        # Collect from [project.optional-dependencies]
+        if 'optional-dependencies' in pyproject['project']:
+            deps_sources.extend(pyproject['project']['optional-dependencies'].values())
+
+    # Collect from [dependency-groups]
+    if 'dependency-groups' in pyproject:
+        deps_sources.extend(pyproject['dependency-groups'].values())
+
+    # Parse list format dependencies
+    for deps in deps_sources:
+        if isinstance(deps, list):
+            for dep_spec in deps:
+                if not isinstance(dep_spec, str):
+                    continue
+                result = _parse_pep621_dependency(dep_spec)
+                if result:
+                    name, version = result
+                    versions[name] = version
+
+    return versions
+
+
+def _collect_poetry_dependencies(pyproject: dict) -> dict[str, str]:
+    """Collect dependencies from Poetry format sections.
+
+    Args:
+        pyproject: Parsed pyproject.toml data
+
+    Returns:
+        Dictionary mapping package names to versions
+
+    """
+    versions: dict[str, str] = {}
+
+    if 'tool' not in pyproject or 'poetry' not in pyproject['tool']:
+        return versions
+
+    poetry_config = pyproject['tool']['poetry']
+
+    # Collect from [tool.poetry.dependencies]
+    deps_sources: list[dict] = [poetry_config.get('dependencies', {})]
+
+    # Collect from [tool.poetry.group.*.dependencies]
+    poetry_groups = poetry_config.get('group', {})
+    deps_sources.extend([group.get('dependencies', {}) for group in poetry_groups.values()])
+
+    # Parse dict format dependencies
+    for deps in deps_sources:
+        if isinstance(deps, dict):
+            for name, value in deps.items():
+                if name == 'python':
+                    continue
+                version = value if isinstance(value, str) else value.get('version') if isinstance(value, dict) else None
+                if version:
+                    versions[name] = _extract_base_version(version)
+
+    return versions
+
+
 def _collect_pyproject_versions(pyproject_text: str) -> dict[str, str]:
     """Return pyproject versions without version specification for possible replacement.
 
@@ -28,55 +142,107 @@ def _collect_pyproject_versions(pyproject_text: str) -> dict[str, str]:
     """
     pyproject = tomllib.loads(pyproject_text)
 
-    pyproject_versions: dict[str, str] = {}
+    # Collect from both UV and Poetry formats
+    uv_versions = _collect_uv_dependencies(pyproject)
+    poetry_versions = _collect_poetry_dependencies(pyproject)
 
-    # Collect dependencies from different formats
-    deps_sources = []
+    # Merge, preferring UV versions if both exist
+    return {**poetry_versions, **uv_versions}
 
-    # UV format: [project.dependencies] and [dependency-groups]
-    if 'project' in pyproject:
-        if 'dependencies' in pyproject['project']:
-            deps_sources.append(pyproject['project']['dependencies'])
 
-        # Optional dependencies
-        if 'optional-dependencies' in pyproject['project']:
-            deps_sources.extend(pyproject['project']['optional-dependencies'].values())
+def _replace_poetry_versions(
+    line: str,
+    name: str,
+    lock_version: str,
+    pyproject_version: str,
+) -> str | None:
+    """Replace version in Poetry dict format line.
 
-    # UV dependency-groups
-    if 'dependency-groups' in pyproject:
-        deps_sources.extend(pyproject['dependency-groups'].values())
+    Args:
+        line: Line from pyproject.toml
+        name: Package name
+        lock_version: New version from lock file
+        pyproject_version: Current version in pyproject
 
-    # Poetry format: [tool.poetry.dependencies] and groups
-    if 'tool' in pyproject and 'poetry' in pyproject['tool']:
-        deps_sources.append(pyproject['tool']['poetry']['dependencies'])
+    Returns:
+        Updated line or None if no replacement made
 
-        pyproject_groups = pyproject['tool']['poetry'].get('group', {})
-        deps_sources.extend([group.get('dependencies', {}) for group in pyproject_groups.values()])
+    """
+    if pyproject_version != lock_version and pyproject_version in line:
+        LOGGER.text(
+            'Upgrade minimum package version',
+            name=name,
+            new_version=lock_version,
+            old_version=pyproject_version,
+        )
+        return line.replace(pyproject_version, lock_version, 1)
+    return None
 
-    # Process all dependency sources
-    for deps in deps_sources:
-        if isinstance(deps, list):
-            # UV format: list of strings like "package>=1.0.0"
-            for dep_spec in deps:
-                if not isinstance(dep_spec, str):
-                    continue
-                # Parse "package>=1.0.0" format
-                match = re.match(r'^([a-zA-Z0-9_-]+)([><=!]+.+)?$', dep_spec)
-                if match:
-                    name = match.group(1)
-                    version_spec = match.group(2) or ''
-                    if version_spec:
-                        pyproject_versions[name] = _extract_base_version(version_spec)
-        elif isinstance(deps, dict):
-            # Poetry format: dict of {package: version}
-            for name, value in deps.items():
-                if name == 'python':
-                    continue
-                version = value if isinstance(value, str) else value.get('version') if isinstance(value, dict) else None
-                if version:
-                    pyproject_versions[name] = _extract_base_version(version)
 
-    return pyproject_versions
+def _replace_pep621_versions(
+    line: str,
+    lock_versions: dict[str, str],
+    pyproject_versions: dict[str, str],
+) -> str | None:
+    """Replace version in PEP 621 list format line.
+
+    Args:
+        line: Line from pyproject.toml (e.g., '  "package>=1.0.0",')
+        lock_versions: Versions from lock file
+        pyproject_versions: Current versions in pyproject
+
+    Returns:
+        Updated line or None if no replacement made
+
+    """
+    # Extract package spec from line (handle quotes and commas)
+    stripped = line.strip().strip('"\'').rstrip(',')
+    result = _parse_pep621_dependency(stripped)
+
+    if not result:
+        return None
+
+    name, _ = result
+
+    lock_version = lock_versions.get(name)
+    pyproject_version = pyproject_versions.get(name)
+
+    if not (lock_version and pyproject_version):
+        return None
+
+    if pyproject_version != lock_version and pyproject_version in line:
+        LOGGER.text(
+            'Upgrade minimum package version',
+            name=name,
+            new_version=lock_version,
+            old_version=pyproject_version,
+        )
+        return line.replace(pyproject_version, lock_version, 1)
+
+    return None
+
+
+def _is_dependency_section(section: str) -> bool:
+    """Check if section is dependency-related."""
+    section_lower = section.lower()
+    return any(keyword in section_lower for keyword in ['dependencies', 'project', 'poetry'])
+
+
+def _try_replace_poetry_line(
+    line: str,
+    lock_versions: dict[str, str],
+    pyproject_versions: dict[str, str],
+) -> str | None:
+    """Try to replace version in Poetry dict format line."""
+    name = line.split('=')[0].strip()
+    lock_version = lock_versions.get(name)
+    pyproject_version = pyproject_versions.get(name)
+
+    if lock_version and pyproject_version:
+        return _replace_poetry_versions(line, name, lock_version, pyproject_version)
+    if lock_version and not pyproject_version:
+        LOGGER.text('WARNING: consider manually updating the version', new_version=lock_version)
+    return None
 
 
 def _replace_pyproject_versions(
@@ -84,30 +250,49 @@ def _replace_pyproject_versions(
     pyproject_versions: dict[str, str],
     pyproject_text: str,
 ) -> str:
-    """Return pyproject text with replaced versions."""
+    """Return pyproject text with replaced versions.
+
+    Handles both Poetry dict format and PEP 621 list format.
+
+    """
     new_lines: list[str] = []
     active_section = ''
+    in_dependency_list = False
+
     for line in pyproject_text.split('\n'):
+        # Track current section
         if line.startswith('['):
             active_section = line
-        elif '=' in line and 'dependencies' in active_section:
-            name = line.split('=')[0].strip()
-            if (lock_version := lock_versions.get(name)) and (pyproject_version := pyproject_versions.get(name)):
-                versions = {'name': name, 'new_version': lock_version, 'old_version': pyproject_version}
-                if pyproject_version != lock_version:
-                    if pyproject_version in line:
-                        new_lines.append(line.replace(pyproject_version, lock_version, 1))
-                        LOGGER.text('Upgrade minimum package version', **versions)  # type: ignore[arg-type]
-                        continue
-                    LOGGER.warning(
-                        'Could not set new version. Please do so manually and submit a bug report',
-                        line=line,
-                        **versions,
-                    )
-            elif lock_version and not pyproject_versions.get(name):
-                LOGGER.text('WARNING: consider manually updating the version', new_version=lock_version)
+            in_dependency_list = False
+
+        is_dep_section = _is_dependency_section(active_section)
+
+        # Handle lines with '=' in dependency sections
+        if '=' in line and is_dep_section and not line.strip().startswith('#'):
+            if line.strip().endswith('['):
+                in_dependency_list = True
+            elif not in_dependency_list and ']' not in line and (
+                replaced := _try_replace_poetry_line(line, lock_versions, pyproject_versions)
+            ):
+                new_lines.append(replaced)
+                continue
+
+        # Try PEP 621 list format
+        has_quotes = '"' in line or "'" in line
+        if (
+            in_dependency_list
+            and has_quotes
+            and (replaced := _replace_pep621_versions(line, lock_versions, pyproject_versions))
+        ):
+            new_lines.append(replaced)
+            continue
+
+        # Check if we're leaving a list
+        if in_dependency_list and line.strip() == ']':
+            in_dependency_list = False
 
         new_lines.append(line)
+
     return '\n'.join(new_lines)
 
 

--- a/tests/experiments/test_sync_package_dependencies.py
+++ b/tests/experiments/test_sync_package_dependencies.py
@@ -5,8 +5,11 @@ from textwrap import dedent
 
 from calcipy.experiments.sync_package_dependencies import (
     _collect_pyproject_versions,
+    _collect_poetry_dependencies,
+    _collect_uv_dependencies,
     _extract_base_version,
     _parse_lock_file,
+    _parse_pep621_dependency,
     _replace_pyproject_versions,
 )
 
@@ -16,10 +19,31 @@ def test_extract_base_version():
     assert _extract_base_version('>=1.0.0,<2.0.0') == '1.0.0'
     assert _extract_base_version('1.0.0') == '1.0.0'
     assert _extract_base_version('^1.0.0') == '1.0.0'
+    assert _extract_base_version('~=1.2.3') == '1.2.3'
 
 
-def test_collect_pyproject_versions():
-    """Test _collect_pyproject_versions function."""
+def test_parse_pep621_dependency():
+    """Test _parse_pep621_dependency function."""
+    # Simple package
+    assert _parse_pep621_dependency('requests>=2.0.0') == ('requests', '2.0.0')
+    assert _parse_pep621_dependency('flask==3.0.0') == ('flask', '3.0.0')
+
+    # Package with single extra
+    assert _parse_pep621_dependency('mkdocstrings[python]>=0.26.1') == ('mkdocstrings', '0.26.1')
+
+    # Package with multiple extras
+    assert _parse_pep621_dependency('package[extra1,extra2]>=1.0.0') == ('package', '1.0.0')
+
+    # Package without version
+    assert _parse_pep621_dependency('package') is None
+    assert _parse_pep621_dependency('package[extra]') is None
+
+    # Complex version specifiers
+    assert _parse_pep621_dependency('package>=1.0.0,<2.0.0') == ('package', '1.0.0')
+
+
+def test_collect_pyproject_versions_poetry():
+    """Test _collect_pyproject_versions with Poetry format."""
     pyproject_text = """
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -30,8 +54,8 @@ flask = "2.0.0"
     assert versions == {'requests': '2.0.0', 'flask': '2.0.0'}
 
 
-def test_replace_pyproject_versions():
-    """Test _replace_pyproject_versions function."""
+def test_replace_pyproject_versions_poetry():
+    """Test _replace_pyproject_versions with Poetry format."""
     pyproject_text = """
 [tool.poetry.dependencies]
 requests = ">=2.0.0,<3.0.0"
@@ -42,6 +66,75 @@ flask = "2.0.0"
     new_text = _replace_pyproject_versions(lock_versions, pyproject_versions, pyproject_text)
     assert '>=2.1.0,<3.0.0' in new_text
     assert 'flask = "2.1.0"' in new_text
+
+
+def test_collect_uv_dependencies():
+    """Test _collect_uv_dependencies function."""
+    pyproject_text = dedent("""
+        [project]
+        dependencies = [
+            "requests>=2.0.0",
+            "flask>=2.0.0",
+        ]
+
+        [project.optional-dependencies]
+        dev = [
+            "pytest>=7.0.0",
+        ]
+
+        [dependency-groups]
+        docs = [
+            "mkdocs>=1.5.0",
+        ]
+    """)
+    from corallium.tomllib import tomllib
+
+    pyproject = tomllib.loads(pyproject_text)
+    versions = _collect_uv_dependencies(pyproject)
+    assert versions == {
+        'requests': '2.0.0',
+        'flask': '2.0.0',
+        'pytest': '7.0.0',
+        'mkdocs': '1.5.0',
+    }
+
+
+def test_collect_uv_dependencies_with_extras():
+    """Test _collect_uv_dependencies handles packages with extras."""
+    pyproject_text = dedent("""
+        [project]
+        dependencies = [
+            "mkdocstrings[python]>=0.26.1",
+            "hypothesis[cli]>=6.112.4",
+        ]
+    """)
+    from corallium.tomllib import tomllib
+
+    pyproject = tomllib.loads(pyproject_text)
+    versions = _collect_uv_dependencies(pyproject)
+    assert versions == {
+        'mkdocstrings': '0.26.1',
+        'hypothesis': '6.112.4',
+    }
+
+
+def test_collect_poetry_dependencies():
+    """Test _collect_poetry_dependencies function."""
+    pyproject_text = dedent("""
+        [tool.poetry.dependencies]
+        requests = ">=2.0.0"
+        flask = "2.0.0"
+
+        [tool.poetry.group.dev.dependencies]
+        pytest = "^7.0.0"
+    """)
+    from corallium.tomllib import tomllib
+
+    pyproject = tomllib.loads(pyproject_text)
+    versions = _collect_poetry_dependencies(pyproject)
+    assert 'requests' in versions
+    assert 'flask' in versions
+    assert 'pytest' in versions
 
 
 def test_collect_pyproject_versions_uv_format():
@@ -90,6 +183,44 @@ def test_collect_pyproject_versions_mixed_format():
     assert versions['flask'] == '2.0.0'
 
 
+def test_replace_pyproject_versions_pep621_format():
+    """Test _replace_pyproject_versions with PEP 621 list format."""
+    pyproject_text = dedent("""
+        [project]
+        dependencies = [
+            "requests>=2.0.0",
+            "flask>=2.0.0",
+        ]
+    """)
+    lock_versions = {'requests': '2.1.0', 'flask': '2.1.0'}
+    pyproject_versions = {'requests': '2.0.0', 'flask': '2.0.0'}
+    new_text = _replace_pyproject_versions(lock_versions, pyproject_versions, pyproject_text)
+
+    # Check that versions were updated
+    assert 'requests>=2.1.0' in new_text
+    assert 'flask>=2.1.0' in new_text
+    # Ensure old versions are gone
+    assert 'requests>=2.0.0' not in new_text
+    assert 'flask>=2.0.0' not in new_text
+
+
+def test_replace_pyproject_versions_pep621_with_extras():
+    """Test _replace_pyproject_versions with packages that have extras."""
+    pyproject_text = dedent("""
+        [project.optional-dependencies]
+        doc = [
+            "mkdocstrings[python]>=0.26.1",
+        ]
+    """)
+    lock_versions = {'mkdocstrings': '0.27.0'}
+    pyproject_versions = {'mkdocstrings': '0.26.1'}
+    new_text = _replace_pyproject_versions(lock_versions, pyproject_versions, pyproject_text)
+
+    # Check that version was updated while preserving extras
+    assert 'mkdocstrings[python]>=0.27.0' in new_text
+    assert 'mkdocstrings[python]>=0.26.1' not in new_text
+
+
 def test_parse_lock_file_uv(tmp_path: Path):
     """Test _parse_lock_file with uv.lock format."""
     uv_lock = tmp_path / 'uv.lock'
@@ -124,3 +255,48 @@ def test_parse_lock_file_poetry(tmp_path: Path):
 
     versions = _parse_lock_file(poetry_lock)
     assert versions == {'requests': '2.31.0', 'flask': '3.0.0'}
+
+
+def test_end_to_end_uv_replacement(tmp_path: Path):
+    """Test end-to-end version replacement for UV format."""
+    # Create uv.lock
+    uv_lock = tmp_path / 'uv.lock'
+    uv_lock.write_text(dedent("""
+        version = 1
+
+        [[package]]
+        name = "requests"
+        version = "2.31.0"
+
+        [[package]]
+        name = "mkdocstrings"
+        version = "0.27.0"
+    """))
+
+    # Create pyproject.toml
+    pyproject = tmp_path / 'pyproject.toml'
+    pyproject.write_text(dedent("""
+        [project]
+        name = "test-package"
+        dependencies = [
+            "requests>=2.28.0",
+        ]
+
+        [project.optional-dependencies]
+        doc = [
+            "mkdocstrings[python]>=0.26.0",
+        ]
+    """))
+
+    # Run replacement
+    from calcipy.experiments.sync_package_dependencies import replace_versions
+
+    replace_versions(uv_lock)
+
+    # Verify results
+    result = pyproject.read_text()
+    assert 'requests>=2.31.0' in result
+    assert 'mkdocstrings[python]>=0.27.0' in result
+    # Ensure old versions are gone
+    assert 'requests>=2.28.0' not in result
+    assert 'mkdocstrings[python]>=0.26.0' not in result

--- a/tests/experiments/test_sync_package_dependencies.py
+++ b/tests/experiments/test_sync_package_dependencies.py
@@ -1,9 +1,12 @@
 """Tests for sync_package_dependencies."""
 
+from pathlib import Path
+from textwrap import dedent
 
 from calcipy.experiments.sync_package_dependencies import (
     _collect_pyproject_versions,
     _extract_base_version,
+    _parse_lock_file,
     _replace_pyproject_versions,
 )
 
@@ -39,3 +42,85 @@ flask = "2.0.0"
     new_text = _replace_pyproject_versions(lock_versions, pyproject_versions, pyproject_text)
     assert '>=2.1.0,<3.0.0' in new_text
     assert 'flask = "2.1.0"' in new_text
+
+
+def test_collect_pyproject_versions_uv_format():
+    """Test _collect_pyproject_versions with UV format."""
+    pyproject_text = dedent("""
+        [project]
+        dependencies = [
+            "requests>=2.0.0",
+            "flask>=2.0.0",
+        ]
+
+        [project.optional-dependencies]
+        dev = [
+            "pytest>=7.0.0",
+        ]
+
+        [dependency-groups]
+        docs = [
+            "mkdocs>=1.5.0",
+        ]
+    """)
+    versions = _collect_pyproject_versions(pyproject_text)
+    assert versions == {
+        'requests': '2.0.0',
+        'flask': '2.0.0',
+        'pytest': '7.0.0',
+        'mkdocs': '1.5.0',
+    }
+
+
+def test_collect_pyproject_versions_mixed_format():
+    """Test _collect_pyproject_versions with both poetry and uv formats."""
+    pyproject_text = dedent("""
+        [project]
+        dependencies = [
+            "requests>=2.0.0",
+        ]
+
+        [tool.poetry.dependencies]
+        flask = "2.0.0"
+    """)
+    versions = _collect_pyproject_versions(pyproject_text)
+    assert 'requests' in versions
+    assert 'flask' in versions
+    assert versions['requests'] == '2.0.0'
+    assert versions['flask'] == '2.0.0'
+
+
+def test_parse_lock_file_uv(tmp_path: Path):
+    """Test _parse_lock_file with uv.lock format."""
+    uv_lock = tmp_path / 'uv.lock'
+    uv_lock.write_text(dedent("""
+        version = 1
+
+        [[package]]
+        name = "requests"
+        version = "2.31.0"
+
+        [[package]]
+        name = "flask"
+        version = "3.0.0"
+    """))
+
+    versions = _parse_lock_file(uv_lock)
+    assert versions == {'requests': '2.31.0', 'flask': '3.0.0'}
+
+
+def test_parse_lock_file_poetry(tmp_path: Path):
+    """Test _parse_lock_file with poetry.lock format."""
+    poetry_lock = tmp_path / 'poetry.lock'
+    poetry_lock.write_text(dedent("""
+        [[package]]
+        name = "requests"
+        version = "2.31.0"
+
+        [[package]]
+        name = "flask"
+        version = "3.0.0"
+    """))
+
+    versions = _parse_lock_file(poetry_lock)
+    assert versions == {'requests': '2.31.0', 'flask': '3.0.0'}

--- a/uv.lock
+++ b/uv.lock
@@ -170,6 +170,25 @@ dependencies = [
 ddict = [
     { name = "python-box" },
 ]
+dev = [
+    { name = "arrow" },
+    { name = "commitizen" },
+    { name = "griffe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mypy" },
+    { name = "nox" },
+    { name = "pymdown-extensions" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-watcher" },
+    { name = "pyyaml" },
+    { name = "ruff" },
+    { name = "semver" },
+]
 doc = [
     { name = "commitizen" },
     { name = "mkdocs" },
@@ -197,6 +216,11 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
     { name = "pytest-watcher" },
+]
+tool = [
+    { name = "arrow" },
+    { name = "pyyaml" },
+    { name = "ruff" },
 ]
 types = [
     { name = "mypy" },
@@ -245,31 +269,51 @@ maintain = [
 
 [package.metadata]
 requires-dist = [
+    { name = "arrow", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "arrow", marker = "extra == 'tags'", specifier = ">=1.3.0" },
+    { name = "arrow", marker = "extra == 'tool'", specifier = ">=1.3.0" },
     { name = "beartype", specifier = ">=0.19.0" },
+    { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.29.1" },
     { name = "commitizen", marker = "extra == 'doc'", specifier = ">=3.29.1" },
     { name = "corallium", specifier = ">=2.1.1" },
+    { name = "griffe", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "griffe", marker = "extra == 'experimental'", specifier = ">=1.3.2" },
     { name = "invoke", specifier = ">=2.2.0" },
     { name = "keyring", specifier = ">=25.5.0" },
+    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.1" },
     { name = "mkdocs", marker = "extra == 'doc'", specifier = ">=1.6.1" },
+    { name = "mkdocs-gen-files", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'doc'", specifier = ">=0.5.0" },
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.39" },
     { name = "mkdocs-material", marker = "extra == 'doc'", specifier = ">=9.5.39" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.26.1" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'doc'", specifier = ">=0.26.1" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
     { name = "mypy", marker = "extra == 'types'", specifier = ">=1.11.2" },
+    { name = "nox", marker = "extra == 'dev'", specifier = ">=2024.10.9" },
     { name = "nox", marker = "extra == 'nox'", specifier = ">=2024.10.9" },
     { name = "pydantic", specifier = ">=2.9.2" },
+    { name = "pymdown-extensions", marker = "extra == 'dev'", specifier = ">=10.11.2" },
     { name = "pymdown-extensions", marker = "extra == 'doc'", specifier = ">=10.11.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0.0" },
+    { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15.0" },
     { name = "pytest-randomly", marker = "extra == 'test'", specifier = ">=3.15.0" },
+    { name = "pytest-watcher", marker = "extra == 'dev'", specifier = ">=0.4.3" },
     { name = "pytest-watcher", marker = "extra == 'test'", specifier = ">=0.4.3" },
     { name = "python-box", marker = "extra == 'ddict'", specifier = ">=7.2.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.2" },
     { name = "pyyaml", marker = "extra == 'tags'", specifier = ">=6.0.2" },
+    { name = "pyyaml", marker = "extra == 'tool'", specifier = ">=6.0.2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.2" },
     { name = "ruff", marker = "extra == 'lint'", specifier = ">=0.8.2" },
+    { name = "ruff", marker = "extra == 'tool'", specifier = ">=0.8.2" },
+    { name = "semver", marker = "extra == 'dev'", specifier = ">=3.0.2" },
     { name = "semver", marker = "extra == 'experimental'", specifier = ">=3.0.2" },
 ]
-provides-extras = ["ddict", "doc", "experimental", "lint", "nox", "tags", "test", "types"]
+provides-extras = ["tool", "dev", "ddict", "doc", "experimental", "lint", "nox", "tags", "test", "types"]
 
 [package.metadata.requires-dev]
 ci = [
@@ -877,7 +921,7 @@ name = "importlib-metadata"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767, upload-time = "2025-01-20T22:21:30.429Z" }
 wheels = [


### PR DESCRIPTION
This commit addresses issue #136 and completes the migration from poetry to uv with improved tool vs dependency usage patterns.

## Poetry → UV Migration Cleanup

- **sync_package_dependencies.py**: Updated to support both poetry.lock and uv.lock formats
  - Added `_parse_lock_file()` to handle both lock file types
  - Updated `_collect_pyproject_versions()` to support [dependency-groups] and [project.dependencies]
  - Maintains backward compatibility with poetry projects

- **Tests**: Added comprehensive test coverage for uv.lock parsing
  - `test_parse_lock_file_uv()` - Tests uv.lock format parsing
  - `test_parse_lock_file_poetry()` - Tests poetry.lock format (backward compat)
  - `test_collect_pyproject_versions_uv_format()` - Tests uv dependency format
  - `test_collect_pyproject_versions_mixed_format()` - Tests mixed formats

## Tool-First Architecture (Issue #136)

- **New Dependency Groups**:
  - `tool`: Minimal deps for standalone CLI usage (ruff, arrow, pyyaml)
  - `dev`: Full development environment (all tools and dependencies)
  - Maintains individual extras for backward compatibility

- **Task Categorization**:
  - Standalone: `calcipy-lint`, `calcipy-tags` (work without project context)
  - Project-context: `calcipy-test`, `calcipy-types`, `calcipy-docs`, `calcipy-pack`

- **Documentation Updates**:
  - **README**: Clear separation of tool vs dependency installation modes
  - **MIGRATION.md**: Comprehensive poetry→uv migration guide
  - Documented mise + uv + nox integration for Python version management
  - Added troubleshooting section for common issues

## Benefits

- Users can now use calcipy as a lightweight tool without project dependencies
- Clear installation paths: `uv tool install 'calcipy[tool]'` vs `uv add --dev 'calcipy[dev]'`
- Reduces adoption barriers and dependency conflicts (addresses #136)
- Maintains full backward compatibility with existing usage patterns

## Testing

- All 74 tests pass
- New tests added for uv.lock support
- Verified both tool and dev installation modes work correctly

<!-- Thanks for contributing!
  To help speed up the code review process, please provide the following information:
  - A short summary of the purpose and links to any relevant GitHub Issues
  - A brief high-level summary of what changed
  - Any additional context or screenshots that would be helpful
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces UV-focused, tool-first workflow (docs + config) and enhances dependency sync to parse/update uv.lock/PEP 621, with comprehensive tests.
> 
> - **Docs**:
>   - **README**: Clarify two usage modes with commands for `calcipy[tool]` vs `calcipy[dev]`.
>   - **Migration Guide**: Add detailed Poetry → UV migration, CI updates, and mise+uv+nox integration.
> - **Config**:
>   - `pyproject.toml`: Add `project.optional-dependencies.{tool,dev}`; retain existing extras.
> - **Experiments/Tooling**:
>   - `src/calcipy/experiments/sync_package_dependencies.py`: Support `uv.lock` alongside `poetry.lock`; parse PEP 621 (`[project]`, `[dependency-groups]`) and Poetry sections; update version replacement logic for list/dict formats; introduce `_parse_lock_file` and helpers.
> - **Tests**:
>   - Add extensive tests for UV/Poetry parsing, PEP 621 handling, and end-to-end version replacement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b15cf9b3f986ae47a142092cc8c9c07783b39cee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UV package manager support alongside Poetry and a standalone tool mode for CLI tasks (linting, tag collection, testing, docs, packaging).

* **Documentation**
  * Expanded installation and quick-start into dual-mode (Standalone Tool vs Project Dependency) with concrete commands.
  * Added a detailed Poetry→UV migration guide with step-by-step migration and CI guidance.

* **Tests**
  * Added extensive tests covering UV, Poetry, and PEP 621 dependency formats and lockfile parsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->